### PR TITLE
Updated to use .Net Core v3.1

### DIFF
--- a/csharp/BlackJack.Tests/BlackJack.Tests.csproj
+++ b/csharp/BlackJack.Tests/BlackJack.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/csharp/BlackJack/BlackJack.csproj
+++ b/csharp/BlackJack/BlackJack.csproj
@@ -2,7 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Interfaces\" />
+  </ItemGroup>
 
 </Project>

--- a/csharp/BlackJack/Program.cs
+++ b/csharp/BlackJack/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace BlackJack
 {


### PR DESCRIPTION
Currently the C# projects are set up to use .Net Core v3.0. The v3.1 version is the LTS version and so it should be updated.